### PR TITLE
Clip background image previews that overflow bounding box (bug 1029822)

### DIFF
--- a/src/media/css/create.styl
+++ b/src/media/css/create.styl
@@ -194,6 +194,7 @@
             height: 200px;
             width: 200px;
             margin: 20px auto;
+            overflow: hidden;
             position: relative;
             text-align: center;
             vertical-align: top;


### PR DESCRIPTION
## Before:

![screen shot 2014-06-24 at 4 47 21 pm](https://cloud.githubusercontent.com/assets/23885/3378871/55ba486e-fbe9-11e3-93d5-477f40f035c3.png)
## After:

![screen shot 2014-06-24 at 4 47 25 pm](https://cloud.githubusercontent.com/assets/23885/3378876/5cb7b11a-fbe9-11e3-8010-a9d9b12a1b11.png)
