### PR TITLE
Add help text for slug field (bug 1030569)

### DIFF
--- a/src/media/css/create.styl
+++ b/src/media/css/create.styl
@@ -43,9 +43,9 @@
     }
     .help-text {
         color: $light-gray;
+        display: inline-block;
         font-style: italic;
         margin-top: 5px;
-        text-align: right;
     }
     .top-hat-field {
         > label:first-child {
@@ -124,9 +124,13 @@
         margin: 10px 0;
         padding: 10px 15px;
     }
-
-    .boring-text input {
-        width: 33%;
+    .boring-text {
+        .help-text {
+            margin-left: 5px;
+        }
+        input {
+            width: 33%;
+        }
     }
     .color-fields .field {
         display: inline-block;

--- a/src/templates/fields/slug.html
+++ b/src/templates/fields/slug.html
@@ -2,4 +2,6 @@
   <label for="slug" class="inline-label">{{ _('Slug') }}</label>
   <input id="slug" name="slug" type="text" placeholder="my-slug"
          {{ 'disabled' if obj }} {% if obj %}value="{{ obj.slug }}"{% endif %}>
+  {# L10n: Characters allowed in slug fields. #}
+  <p class="help-text">{{ _('Allowed: a-z, hyphen, integers') }}</p>
 </div>


### PR DESCRIPTION
Left-aligned help text to have it work better with `.boring-text`-style fields:

![screen shot 2014-06-30 at 12 39 54 pm](https://cloud.githubusercontent.com/assets/23885/3433297/00412814-007e-11e4-8984-a9de9eaee4bf.png)
![screen shot 2014-06-30 at 12 38 32 pm](https://cloud.githubusercontent.com/assets/23885/3433298/017fe63e-007e-11e4-9f2c-e9854e701334.png)
