### PR TITLE
Handle undefined offset in app selector (bug 1035426)

### DIFF
--- a/src/media/js/app_selector.js
+++ b/src/media/js/app_selector.js
@@ -24,7 +24,7 @@ define('app_selector',
     }, 250))
 
     .on('click', '.app-selector .paginator a', function() {
-        var offset = parseInt($paginator.attr('data-offset'), 10);
+        var offset = parseInt($paginator.attr('data-offset'), 10) || 0;
         if ($(this).hasClass('prev')) {
             offset = offset - 5;
         } else {


### PR DESCRIPTION
r? @ngokevin

I'm not sure how data-offset is returning `undefined`, but we should handle that case anyway.
