### PR TITLE
Hide the appropriate reorder buttons on the first and last app in the list of selected apps in the multiple-app selector.

### DIFF
--- a/src/media/css/app_selector.styl
+++ b/src/media/css/app_selector.styl
@@ -108,11 +108,11 @@
     .result {
         transition(background .1s);
         border-top: 1px solid $light-gray-grayscale-primary;
+        cursor: move;
         padding: 15px 5px 10px 10px;
         position: relative;
 
         &:hover {
-            cursor: pointer;
             background: $faint-blue;
         }
 


### PR DESCRIPTION
Janky selectors, open to suggestions. Tried to get `:first-of-type` and `:last-of-type` to work. They didn't.

![screen shot 2014-07-22 at 2 36 55 pm](https://cloud.githubusercontent.com/assets/23885/3663925/e68f0dda-11d7-11e4-9fb8-655fe27de818.png)
