### PR TITLE
Restrict max height of feed preview to the appx height of the Flame's screen, less Firefox OS and Marketplace chrome.

### DIFF
--- a/src/media/css/transsonic.styl
+++ b/src/media/css/transsonic.styl
@@ -1,5 +1,7 @@
 @import 'lib';
 
+$appx-flame-height = 680px;
+
 @-webkit-keyframes spin {
     from { -webkit-transform: rotate(0turn); }
     to { -webkit-transform: rotate(1turn); }
@@ -162,7 +164,7 @@ h3 {
 
             > h3 {
                 background: $blue-action-primary;
-                bottom: 0;
+                bottom: -10px;
                 color: $white;
                 font-size: 12px;
                 font-weight: bold;
@@ -177,7 +179,9 @@ h3 {
 
         .screen {
             background: $light-gray-grayscale-primary;
+            max-height: $appx-flame-height;
             margin: 0 auto;
+            overflow: scroll;
             padding: 10px;
             width: 320px;
         }


### PR DESCRIPTION
Per Krupa's request. Something something "the fold" something something.

r? @ngokevin

![screen shot 2014-07-24 at 6 14 59 pm](https://cloud.githubusercontent.com/assets/23885/3696081/729b94e0-1388-11e4-8ba6-002eb0efa361.png)
