### PR TITLE
Do not display collection icons if a background image is included (bug 1049193)

### DIFF
--- a/src/media/css/feed.styl
+++ b/src/media/css/feed.styl
@@ -561,17 +561,33 @@ $vertical-tile-margin = 10px;
         &.full {
             min-height: 235px;
 
+            .has-background& {
+                min-height: 175px;
+            }
+
             .curve {
                 top: 30px;
             }
             .info {
                 top: 83px;
+
+                .has-background& {
+                    top: 50px;
+                }
             }
             .alt-curve {
                 top: 135px;
+
+                .has-background& {
+                    top: 85px;
+                }
             }
             .desc {
                 top: 150px;
+
+                .has-background& {
+                    top: 110px;
+                }
             }
         }
     }
@@ -619,6 +635,9 @@ $vertical-tile-margin = 10px;
         &.mega.full .desc {
             top: 155px;
         }
+        &.mega.full.has-background .desc {
+            top: 110px;
+        }        
     }
     &.shelf-landing {
         .feed-item {

--- a/src/templates/_macros/feed_item.html
+++ b/src/templates/_macros/feed_item.html
@@ -105,17 +105,19 @@
 
   <a href="{{ url('feed/feed_collection', [coll.slug])|urlparams(src='feed') }}"
      class="fanchor">
-    <section class="feed-item full {{ 'mega' if desc }}"
+    <section class="feed-item full {{ 'mega' if desc }} {{ 'has-background' if coll.background_image }}"
                     {% if coll.background_image %}
                       style="background-image: url({{ coll.background_image }})"
                     {% else %}
                       style="background-color: {{ color|hex2rgba('.4') }}"
                    {% endif %}>
-      <ul class="app-icons">
-        {% for app in coll.apps.slice(0, 3) %}
-          <li>{{ deferred_icon(app.icons[64], app.name|translate(app)) }}</li>
-        {% endfor %}
-      </ul>
+      {% if not coll.background_image %}
+        <ul class="app-icons">
+          {% for app in coll.apps.slice(0, 3) %}
+            <li>{{ deferred_icon(app.icons[64], app.name|translate(app)) }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       <div class="curve" style="background-color: {{ color|hex2rgba('.6') }}"></div>
       <div class="info">
         <h1 class="name">{{ coll.name|translate(coll)|safe }}</h1>


### PR DESCRIPTION
r? @ngokevin @spasovski

Note: this does not fix the existing bug where a promo does not expand past its min-height because its contents are all absolutely positioned.
## Before

![screen shot 2014-08-07 at 10 47 23 am](https://cloud.githubusercontent.com/assets/23885/3845469/d852ad44-1e52-11e4-88f9-b58a89ad669c.png)
## After

![screen shot 2014-08-07 at 10 47 28 am](https://cloud.githubusercontent.com/assets/23885/3845471/dd224f6e-1e52-11e4-84ae-3198b9664f5d.png)
