### PR TITLE
Truncate operator shelf names in listing page (bug 1056895)

### DIFF
--- a/src/templates/listing/shelf.html
+++ b/src/templates/listing/shelf.html
@@ -4,7 +4,7 @@
     {% if shelf.app_count or shelf.apps.length %}
       <img class="icon" src="{{ shelf.preview_icon or shelf.apps[0].icons['32'] }}">
     {% endif %}
-    <h3>{{ _('{name} ({num_apps} apps)')|format({name: shelf.name,
+    <h3 class="elliflow">{{ _('{name} ({num_apps} apps)')|format({name: shelf.name,
                                                  num_apps: shelf.app_count or shelf.apps.length}) }}</h3>
     <span class="type">
       {{ _('{carrier} - {region}')|format(


### PR DESCRIPTION
Not worth anybody's time to review.
