### PR TITLE
Appropriately include or omit empty translations when submitting to the API (bug 1101263)

### DIFF
--- a/src/media/js/routes.js
+++ b/src/media/js/routes.js
@@ -12,6 +12,7 @@ var routes = window.routes = [
     {'pattern': root + 'manage$', 'view_name': 'listing'},
     {'pattern': root + 'manage/([^/<>"\']+)/([^/<>"\']+)$', 'view_name': 'edit'},
     {'pattern': '/fxa-authorize$', 'view_name': 'fxa_authorize'},
+    {'pattern': '^/tests$', 'view_name': 'tests'}
 ];
 
 define('routes', [
@@ -23,6 +24,7 @@ define('routes', [
     'views/home',
     'views/listing',
     'views/login',
+    'views/tests'
 ], function() {
     for (var i = 0; i < routes.length; i++) {
         var route = routes[i];

--- a/src/media/js/utils_local.js
+++ b/src/media/js/utils_local.js
@@ -4,7 +4,9 @@ define('utils_local', ['jquery', 'log', 'notification', 'nunjucks', 'z'], functi
     function build_localized_field(name) {
         var data = {};
         $('.localized[data-name="' + name + '"]').each(function(i, field) {
-            data[this.getAttribute('data-lang')] = this.value;
+            if (this.value) {
+                data[this.getAttribute('data-lang')] = this.value;
+            }
         });
         return data;
     };

--- a/src/tests/empty_translations.js
+++ b/src/tests/empty_translations.js
@@ -1,0 +1,48 @@
+(function () {
+    var assert = require('assert');
+    var ok_ = assert.ok_;
+    var mock = assert.mock;
+
+    test('translated locales determined', function (done, fail) {
+        var get_translated_locales = require('forms_transonic').get_translated_locales;
+        var data = {
+            'field1': {
+                'lang1': '',
+                'lang2': '',
+                'lang3': 'Val'
+            },
+            'field2': {
+                'lang1': '',
+                'lang2': 'Val',
+                'lang3': ''
+            },
+            'field3': 'Unrelated',
+            'field4': {
+                'this is': 'not translated'
+            }
+        };
+        var locales = get_translated_locales(data, ['field1', 'field2']);
+        ok_(locales.indexOf('lang1') === -1); 
+        ok_(locales.indexOf('lang2') >= 0); 
+        ok_(locales.indexOf('lang3') >= 0); 
+        done();
+    });
+
+    test('empty translatons populated', function (done, fail) {
+        var populate_empty_translations = require('forms_transonic').populate_empty_translations;
+        var data = populate_empty_translations({
+            'field1': {
+                'lang1': 'Val'
+            },
+            'field2': {
+                'lang2': 'Val'
+            }
+        }, ['field1', 'field2']);
+        ok_('lang1' in data['field1']);
+        ok_('lang2' in data['field1']);
+        ok_('lang1' in data['field2']);
+        ok_('lang2' in data['field2']);
+        done();
+    });
+
+})();


### PR DESCRIPTION
r? @ngokevin @spasovski @diox 

We currently submit empty strings for every empty field, for every untranslated locale that transonic supports. This is a problem, because the API differentiates between empty strings and missing keys in translated fields (i.e. similar to how Django differentiates between `blank` and `null`. 

This commit ensures that we only send complete sets of translations, and only then, for locales with a meaningful translation for each field.

Currently, if the user fills out a name and description in English but just a name in Dutch, it will send this data:

```
{
    'name': {
        'bn-BD': '',
        'ca': '',
        'others': '',
        'en': 'Name',
        'nl': 'Naam'
    },
    'description': {
        'bn-BD': '',
        'ca': '',
        'others': '',
        'en': 'Description',
        'nl': ''
    }
}
```

After this patch, it will only submit this:

```
{
    'name': {
        'en': 'Name',
        'nl': 'Naam'
    },
    'description': {
        'en': 'Description',
        'nl': ''
    }
}
```

There will be a companion commit to Zamboni that adds a management command to clean up the existing bad data.
