### PR TITLE
bump m-c-m to 1.6.2 (bug 1125845)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "marketplace-frontend": "7.0.1",
     "marketplace-constants": "0.3.1",
-    "marketplace-core-modules": "1.4.1",
+    "marketplace-core-modules": "1.6.2",
 
     "almond": "0.2.9",
     "jquery": "2.0.2",


### PR DESCRIPTION
r? @mstriemer  I see this depends on marketplace-frontend. I'm not sure what the crossover between m-c-m and fireplace might be for this tree.